### PR TITLE
Drop support for Node.js v18, add v24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x', '22.x']
+        node-version: ['20.x', '22.x', '24.x']
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,6 @@ export default [
         {
           ignores: [
             'fs/promises.cp',
-            'test',
             'test.describe',
             'test.it',
             'test.it.skip',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "release-it": "^19.0.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "release-it": "^19.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Node.js v18 has reached end-of-life.